### PR TITLE
fix: version symantics mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.3",
+  "version": "0.1.30",
   "name": "shadcn-ui",
   "displayName": "shadcn/ui",
   "description": "Add components from shadcn/ui directly from VS Code",


### PR DESCRIPTION
Seems there was issue with version which caused new version to not show up. Please confirm.