### PR TITLE
FEAT: Add tools for copilot agent mode

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,4 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
+pnpm-lock.yaml

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.32",
+  "version": "0.1.33",
   "name": "shadcn-ui",
   "displayName": "shadcn/ui",
   "description": "Add components from shadcn/ui directly from VS Code",
@@ -51,6 +51,39 @@
         "command": "shadcn-ui.gotoDoc",
         "title": "shadcn/ui: Open Documentation"
       }
+    ],
+    "languageModelTools": [
+      {
+        "name": "get_shadcnComponentList",
+        "displayName": "shadcn/ui: Get Component List",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "get_shadcnComponentList",
+        "userDescription": "Get the list of components from shadcn/ui",
+        "modelDescription": "Gets a list of re-usable react (tsx) components from shadcn/ui."
+      },
+      {
+        "name": "install_shadcnComponent",
+        "displayName": "shadcn/ui: Download Component",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "install_shadcnComponent",
+        "userDescription": "Download a component from shadcn/ui",
+        "modelDescription": "Downloads a component from shadcn/ui and adds it to the project automatically, usually under the (root)/components/ directory.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Name(s) of the component to be downloaded. The name should be exactly as it appears in the shadcn/ui documentation."
+            }
+          },
+          "required": [
+            "id"
+          ]
+        }
+      }
     ]
   },
   "scripts": {
@@ -73,6 +106,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.8",
     "@typescript-eslint/parser": "^5.59.8",
     "@vscode/test-electron": "^2.3.2",
+    "@vscode/vsce": "^3.5.0",
     "eslint": "^8.41.0",
     "glob": "^8.1.0",
     "mocha": "^10.2.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,14 +21,13 @@ const commands = {
 } as const;
 
 class GetShadcnComponentListTool implements vscode.LanguageModelTool<{}> {
-  private static registryCache: { data: any; timestamp: number } | null = null;
+  private static registryCache: { data: Components; timestamp: number } | null = null;
   private static readonly cacheTtl = 5 * 60 * 1000; // 5 minutes
 
   async invoke(
     options: vscode.LanguageModelToolInvocationOptions<{}>,
     token: vscode.CancellationToken
   ): Promise<vscode.LanguageModelToolResult> {
-    
       try {
         if (token.isCancellationRequested) {
           return new vscode.LanguageModelToolResult([

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,191 @@ const commands = {
   gotoDoc: "shadcn-ui.gotoDoc",
 } as const;
 
+class GetShadcnComponentListTool implements vscode.LanguageModelTool<{}> {
+  private static registryCache: { data: any; timestamp: number } | null = null;
+  private static readonly cacheTtl = 5 * 60 * 1000; // 5 minutes
+
+  async invoke(
+    options: vscode.LanguageModelToolInvocationOptions<{}>,
+    token: vscode.CancellationToken
+  ): Promise<vscode.LanguageModelToolResult> {
+    
+      try {
+        if (token.isCancellationRequested) {
+          return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart("Operation was cancelled"),
+          ]);
+        }
+
+        const now = Date.now();
+        if (GetShadcnComponentListTool.registryCache && 
+            (now - GetShadcnComponentListTool.registryCache.timestamp) < GetShadcnComponentListTool.cacheTtl) {
+          return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart(JSON.stringify(GetShadcnComponentListTool.registryCache.data)),
+          ]);
+        }
+
+        const components = await getRegistry();
+
+        if (token.isCancellationRequested) {
+          return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart("Operation was cancelled"),
+          ]);
+        }
+
+        if (!components) {
+          return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart(
+              "Failed to fetch component list from shadcn/ui registry"
+            ),
+          ]);
+        }
+
+        // cache the components
+        GetShadcnComponentListTool.registryCache = {
+          data: components,
+          timestamp: Date.now()
+        };
+
+        return new vscode.LanguageModelToolResult([
+          new vscode.LanguageModelTextPart(JSON.stringify(components)),
+        ]);
+      } catch (error) {
+        if (token.isCancellationRequested) {
+          return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart("Operation was cancelled"),
+          ]);
+        }
+        return new vscode.LanguageModelToolResult([
+          new vscode.LanguageModelTextPart(`Error fetching components: ${error}`),
+        ]);
+      }
+    };
+  }
+
+interface InstallComponentInput {
+  id: string[];
+}
+
+class InstallShadcnComponentTool
+  implements vscode.LanguageModelTool<InstallComponentInput>
+{
+  // regex patterns to clean up the output from install commands
+  private static readonly ansiRegex = /([\u001B\u009B][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><]|\u001B|\u0007)/gu;
+  private static readonly spinnerRegex = /^[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\s/g;
+  private static readonly vscodeShellRegex = /]633;C|/g;
+  private static readonly newTerminal = true;
+
+  async invoke(
+    options: vscode.LanguageModelToolInvocationOptions<InstallComponentInput>,
+    token: vscode.CancellationToken
+  ): Promise<vscode.LanguageModelToolResult> {
+      try {
+      // check if we've been cancelled
+      if (token.isCancellationRequested) {
+        return new vscode.LanguageModelToolResult([
+          new vscode.LanguageModelTextPart("Operation was cancelled"),
+        ]);
+      }
+
+      const { id } = options.input;
+
+      if (!id || !Array.isArray(id) || id.length === 0) {
+        return new vscode.LanguageModelToolResult([
+          new vscode.LanguageModelTextPart(
+            "No component names provided. Please specify component name(s) to install."
+          ),
+        ]);
+      }
+
+      const installCmd = await getInstallCmd(id);
+
+      const [terminal, execution, stream] = await executeCommand(
+        installCmd,
+        InstallShadcnComponentTool.newTerminal
+      );
+      if (!execution || !stream) {
+        return new vscode.LanguageModelToolResult([
+          new vscode.LanguageModelTextPart(
+            "Failed to execute the installation command."
+          ),
+        ]);
+      }
+      await logCmd(installCmd);
+      const output: string[] = [];
+      const componentList = id.join(", ");
+      let duplicateCount = 0;
+      let lastLine = "";
+
+      try {
+        for await (let line of stream) {
+          if (token.isCancellationRequested) {
+            break;
+          }
+
+          // clean up the line before pushing it to the output
+          line = line
+            // first regex to remove ANSI escape codes/bash colors
+            .replace(
+              InstallShadcnComponentTool.ansiRegex,
+              ""
+            )
+            // second regex to remove the spinners
+            .replace(InstallShadcnComponentTool.spinnerRegex, "")
+            // third regex to remove VSCode shell integration stuff
+            .replace(InstallShadcnComponentTool.vscodeShellRegex, "")
+            .trim();
+          if (line === "") {
+            continue;
+          }
+          if (line === output[output.length - 1]) {
+            duplicateCount++;
+            lastLine = line;
+            continue; // skip duplicate lines
+          }
+          // add indication for duplicate
+          if (duplicateCount > 0) {
+            const lastOutputIndex = output.length - 1;
+            output[lastOutputIndex] = `${lastLine} [x${duplicateCount + 1}]`;
+            duplicateCount = 0;
+          }
+          output.push(line);
+        }
+      } finally {
+        if (terminal && InstallShadcnComponentTool.newTerminal) {
+          // close the terminal if it was created for us
+          terminal.dispose();
+        }
+      }
+      if (duplicateCount > 0) {
+        const lastOutputIndex = output.length - 1;
+        output[lastOutputIndex] = `${lastLine} [x${duplicateCount + 1}]`;
+      }
+
+      return new vscode.LanguageModelToolResult([
+        new vscode.LanguageModelTextPart(
+          JSON.stringify({
+            output: output.join("\n"),
+            command: installCmd,
+            componentList,
+          })
+        ),
+      ]);
+    } catch (error) {
+      if (token.isCancellationRequested) {
+        return new vscode.LanguageModelToolResult([
+          new vscode.LanguageModelTextPart("Operation was cancelled"),
+        ]);
+      }
+      return new vscode.LanguageModelToolResult([
+        new vscode.LanguageModelTextPart(
+          `Error installing components: ${error}`
+        ),
+      ]);
+    }
+    };
+  }
+
 export function activate(context: vscode.ExtensionContext) {
   let registryData: Components;
 
@@ -38,6 +223,17 @@ export function activate(context: vscode.ExtensionContext) {
     return true;
   };
 
+  const toolDisposables = [
+    vscode.lm.registerTool(
+      "get_shadcnComponentList",
+      new GetShadcnComponentListTool()
+    ),
+    vscode.lm.registerTool(
+      "install_shadcnComponent",
+      new InstallShadcnComponentTool()
+    ),
+  ];
+
   const disposables: vscode.Disposable[] = [
     vscode.commands.registerCommand(commands.initCli, async () => {
       const intCmd = await getInitCmd();
@@ -49,9 +245,12 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(commands.addNewComponent, async () => {
       await checkRegistryData();
 
-      const selectedComponent = await vscode.window.showQuickPick(registryData, {
-        matchOnDescription: true,
-      });
+      const selectedComponent = await vscode.window.showQuickPick(
+        registryData,
+        {
+          matchOnDescription: true,
+        }
+      );
 
       if (!selectedComponent) {
         return;
@@ -63,31 +262,42 @@ export function activate(context: vscode.ExtensionContext) {
       await logCmd(installCmd);
     }),
 
-    vscode.commands.registerCommand(commands.addMultipleComponents, async () => {
-      await checkRegistryData();
+    vscode.commands.registerCommand(
+      commands.addMultipleComponents,
+      async () => {
+        await checkRegistryData();
 
-      const selectedComponents = await vscode.window.showQuickPick(registryData, {
-        matchOnDescription: true,
-        canPickMany: true,
-      });
+        const selectedComponents = await vscode.window.showQuickPick(
+          registryData,
+          {
+            matchOnDescription: true,
+            canPickMany: true,
+          }
+        );
 
-      if (!selectedComponents) {
-        return;
+        if (!selectedComponents) {
+          return;
+        }
+
+        const selectedComponent = selectedComponents.map(
+          (component: { label: string }) => component.label
+        );
+        const installCmd = await getInstallCmd(selectedComponent);
+
+        executeCommand(installCmd);
+        await logCmd(installCmd);
       }
-
-      const selectedComponent = selectedComponents.map((component) => component.label);
-      const installCmd = await getInstallCmd(selectedComponent);
-
-      executeCommand(installCmd);
-      await logCmd(installCmd);
-    }),
+    ),
 
     vscode.commands.registerCommand(commands.gotoComponentDoc, async () => {
       await checkRegistryData();
 
-      const selectedComponent = await vscode.window.showQuickPick(registryData, {
-        matchOnDescription: true,
-      });
+      const selectedComponent = await vscode.window.showQuickPick(
+        registryData,
+        {
+          matchOnDescription: true,
+        }
+      );
 
       if (!selectedComponent) {
         return;
@@ -110,7 +320,7 @@ export function activate(context: vscode.ExtensionContext) {
     }),
   ];
 
-  context.subscriptions.push(...disposables);
+  context.subscriptions.push(...disposables, ...toolDisposables);
 }
 
 // This method is called when your extension is deactivated

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -13,7 +13,7 @@ type OgComponent = {
 
 type Component = {
   label: string;
-  detail?: string;
+  dependencies?: string;
 };
 
 export const shadCnDocUrl = "https://ui.shadcn.com/docs";
@@ -38,7 +38,7 @@ export const getRegistry = async (): Promise<Components | null> => {
   const components: Components = (data as OgComponent[]).map((c) => {
     const component: Component = {
       label: c.name,
-      detail: `dependencies: ${c.dependencies ? c.dependencies.join(" ") : "no dependency"}`,
+      dependencies: `dependencies: ${c.dependencies ? c.dependencies.join(" ") : "no dependency"}`,
     };
 
     return component;

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -1,15 +1,57 @@
 import * as vscode from "vscode";
 
 export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
-
-export const executeCommand = (cmd: string, createNew = true): void => {
+export async function executeCommand (
+  cmd: string,
+  createNew = true,
+  name?: string
+): Promise<[vscode.Terminal, vscode.TerminalShellExecution?, AsyncIterable<string>?]> {
   let terminal = vscode.window.activeTerminal;
   if (createNew || !terminal) {
-    terminal = vscode.window.createTerminal();
+    terminal = vscode.window.createTerminal(name ? name : "ShadCN/UI");
   }
 
   terminal.show();
-  terminal.sendText(cmd);
+  if (!terminal.shellIntegration) {
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        disposable.dispose();
+        reject(new Error("Shell integration timeout"));
+      }, 5000);
+
+      const disposable = vscode.window.onDidChangeTerminalShellIntegration(
+        (e) => {
+          if (e.terminal === terminal) {
+            clearTimeout(timeout);
+            disposable.dispose();
+            resolve();
+          }
+        }
+      );
+
+      if (terminal.shellIntegration) {
+        clearTimeout(timeout);
+        disposable.dispose();
+        resolve();
+      }
+    });
+  }
+
+  if (terminal.shellIntegration) {
+    const res = terminal.shellIntegration.executeCommand(cmd);
+    const stream = res.read();
+    return [terminal, res, stream];
+  } else {
+    terminal.sendText(cmd);
+    vscode.window.onDidStartTerminalShellExecution((e) => {
+      const stream = e.execution.read();
+      if (e.terminal === terminal) {
+        return [terminal, e.execution, stream];
+      }
+    });
+    // if we are hitting this point, something is messed up real bad
+    return [terminal, undefined, undefined];
+  }
 };
 
 export const getFileStat = async (fileName: string) => {


### PR DESCRIPTION
* Added `GetShadcnComponentListTool` and `InstallShadcnComponentTool` classes in `src/extension.ts` to enable fetching a list of components and installing components directly from the `shadcn/ui` registry for copilot agent mode
* Added `@vscode/vsce` as a new development dependency for local builds

### Improvements to Registry Handling:
* Updated the `Component` type in `src/utils/registry.ts` to replace the `detail` field with a `dependencies` field for clarity.
* Modified the `getRegistry` function to correctly populate the `dependencies` field with dependency information.

### Enhancements to Command Execution:
* Refactored the `executeCommand` function in `src/utils/vscode.ts` to support shell integration, asynchronous command execution, and output streaming